### PR TITLE
Upgrade extended_text_field dependency + dark sdk

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,13 +4,13 @@ version: 1.1.0
 homepage: https://github.com/antonioCaballero17/json_text_field
 
 environment:
-  sdk: '>=3.2.0 <4.0.0'
+  sdk: '>=3.4.0 <4.0.0'
   flutter: ">=1.17.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  extended_text_field: ^13.0.0
+  extended_text_field: ^15.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Currently, the plugin uses extended_text_field: ^13.0.0, which unfortunately broke under Flutter 3.22.1, as seen below.
```
../../../.pub-cache/hosted/pub.dev/extended_text_field-13.1.0/lib/src/official/widgets/editable_text.dart:3348:28:
Error: The method 'isSelectionWithinTextBounds' isn't defined for the class 'TextEditingController'.
 - 'TextEditingController' is from 'package:flutter/src/widgets/editable_text.dart' ('/opt/hostedtoolcache/flutter/stable-3.22.1-x64/packages/flutter/lib/src/widgets/editable_text.dart').
    if (!widget.controller.isSelectionWithinTextBounds(selection)) {
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This PR updates pubspec.yaml:
extended_text_field: ^15.0.0
As well as Dart SDK constraints:
sdk: '>=3.4.0 <4.0.0'