### PR TITLE
Upgrade extended_text_field dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,11 +10,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  extended_text_field: ^15.0.0
+  extended_text_field: ^16.0.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.1
+  flutter_lints: ^5.0.0
 
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: json_text_field
 description: "Flutter widget that automatically formats text in a JSON format."
-version: 1.1.0
+version: 1.2.0
 homepage: https://github.com/antonioCaballero17/json_text_field
 
 environment:


### PR DESCRIPTION
One of the Flutter SDK updates (possibly 3.24) broke extended_text_field.
This PR upgrades `extended_text_field` to `^16.0.2`.

I've also bumped the version and linter up.